### PR TITLE
feat: Update profile README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-![Handmade Toys Logo](https://github.com/miyaRyo226/miyaRyo226/assets/55911763/6c73d382-608c-47a9-af43-9d3956f86106)
-<p align="left">
+<h1 align="center">Hi there, I'm miyaRyo226 👋</h1>
+
+<p align="center">
   <a href="https://github.com/miyaRyo226/miyaRyo226/">
     <img src="https://komarev.com/ghpvc/?username=miyaRyo226" alt="miyaRyo226" />
   </a>
@@ -8,22 +9,55 @@
   </a>
 </p>
 
-![](https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=miyaRyo226&theme=tokyonight)
+---
+
+### 👨‍💻 About Me
+
+- 🏠 Lives in Kumamoto, Japan.
+- 🏢 Engineer at TechFeed Inc.
+- 💡 Interested in MCP tools.
+- 🗣️ Known as miyamon.
+
+---
+
+### 🛠️ Languages and Tools
 
 <p align="left">
-<a href="https://github.com/miyaRyo226">
-  <img height="170px" src="https://github-readme-stats.vercel.app/api?username=miyaRyo226&count_private=true&show_icons=true&theme=tokyonight" />
-</a>
+  <a href="https://skillicons.dev">
+    <img src="https://skillicons.dev/icons?i=js,ts,react,nextjs,nodejs,python,fastapi,docker,gcp,aws" />
+  </a>
 </p>
 
-<p align="left">
-<a href="https://github.com/miyaRyo226">
-  <img alt="github stats" height="150px" src="https://github-readme-streak-stats.herokuapp.com/?user=miyaRyo226&count_private=true&show_icons=true&theme=tokyonight" />
-</a>
+---
+
+### 🏆 GitHub Trophy
+
+<p align="center">
+  <a href="https://github.com/ryo-ma/github-profile-trophy">
+    <img src="https://github-profile-trophy.vercel.app/?username=miyaRyo226&theme=tokyonight&column=7" alt="miyaRyo226" />
+  </a>
 </p>
 
-<p align="left">
-<a href="https://github.com/miyaRyo226">
-  <img height="170px" src="https://github-readme-stats.vercel.app/api/top-langs/?username=miyaRyo226&layout=compact&theme=tokyonight" />
-</a>
+---
+
+### 📊 My GitHub Stats
+
+<p align="center">
+  <img src="https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=miyaRyo226&theme=tokyonight" width="100%" />
 </p>
+<br/>
+<p align="center">
+  <a href="https://github.com/miyaRyo226">
+    <img height="170px" src="https://github-readme-stats.vercel.app/api?username=miyaRyo226&count_private=true&show_icons=true&theme=tokyonight" />
+  </a>
+  <a href="https://github.com/miyaRyo226">
+    <img height="170px" src="https://github-readme-stats.vercel.app/api/top-langs/?username=miyaRyo226&layout=compact&theme=tokyonight" />
+  </a>
+</p>
+<p align="center">
+  <a href="https://github.com/miyaRyo226">
+    <img alt="github stats" height="150px" src="https://github-readme-streak-stats.herokuapp.com/?user=miyaRyo226&count_private=true&show_icons=true&theme=tokyonight" />
+  </a>
+</p>
+
+---


### PR DESCRIPTION
GitHubプロフィールのREADMEを更新しました。

### 変更内容

- 自己紹介文を追加・英語化
- スキルアイコンのセクションを追加
- GitHub Trophyを追加し、実績を可視化
- 全体のレイアウトを調整